### PR TITLE
Undo player hack

### DIFF
--- a/components/player/index.js
+++ b/components/player/index.js
@@ -31,7 +31,7 @@ export default class Player extends Component {
   }
 
   render () {
-    const { url, title, playing, setPlayState, togglePlayPause } = this.props
+    const { audioUrl, title, playing, setPlayState, togglePlayPause } = this.props
     const { playedPercent, playedSeconds, duration } = this.state
 
     return (
@@ -41,7 +41,7 @@ export default class Player extends Component {
           className='react-player'
           width='0'
           height='0'
-          url={url}
+          url={audioUrl}
           playing={playing}
           onReady={() => console.log('onReady')}
           onStart={() => console.log('onStart')}

--- a/lib/slugify.js
+++ b/lib/slugify.js
@@ -3,6 +3,6 @@ import slugify from 'slugify'
 export default str => {
   return slugify(str, {
     lower: true,
-    remove: /['!"#$%&\\'()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g
+    remove: /['!"#$%&\\'()*+,\-./:;<=>?@[\\\]^_`{|}~']/g
   })
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,14 @@
 import React from 'react'
 import App, { Container } from 'next/app'
 
+import Player from '../components/player'
+
 export default class extends App {
+  state = {
+    playing: false,
+    playerStory: {}
+  }
+
   static async getInitialProps ({ Component, router, ctx }) {
     let pageProps = {}
 
@@ -12,12 +19,36 @@ export default class extends App {
     return { pageProps }
   }
 
+  setPlayState = state => this.setState({ playing: state })
+
+  togglePlayPause = () => this.setState(prevState => ({
+    playing: !prevState.playing
+  }))
+
+  onStoryPlayClick = story => this.setState({
+    playing: true,
+    playerStory: story
+  })
+
   render () {
     const { Component, pageProps } = this.props
+    const { playing, playerStory } = this.state
 
     return (
       <Container>
-        <Component {...pageProps} />
+        <Component
+          {...pageProps}
+          onStoryPlayClick={this.onStoryPlayClick}
+        />
+        {Object.keys(playerStory).length > 0 && (
+          <Player
+            audioUrl={playerStory.audio && playerStory.audio.publicUrl}
+            title={playerStory.title}
+            playing={playing}
+            setPlayState={this.setPlayState}
+            togglePlayPause={this.togglePlayPause}
+          />
+        )}
       </Container>
     )
   }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import App, { Container } from 'next/app'
+
+export default class extends App {
+  static async getInitialProps ({ Component, router, ctx }) {
+    let pageProps = {}
+
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx)
+    }
+
+    return { pageProps }
+  }
+
+  render () {
+    const { Component, pageProps } = this.props
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    )
+  }
+}

--- a/pages/stories.js
+++ b/pages/stories.js
@@ -4,8 +4,6 @@ import request from 'axios'
 import { Router } from '../routes'
 import Page from '../components/hoc/page'
 import Story from '../components/story'
-import { Participate } from './participate'
-import { SignIn } from './auth/sign-in'
 import Player from '../components/player'
 import config from '../config'
 
@@ -15,14 +13,7 @@ class NewsBody extends Component {
     playerStory: {}
   }
 
-  static async getInitialProps ({ asPath, query }) {
-    // if url is participate then just return participate = true
-    if (asPath === '/participate') {
-      return { participate: true }
-    } else if (asPath === '/sign-in') {
-      return { signIn: true }
-    }
-
+  static async getInitialProps ({ query }) {
     // query.authorSlug comes from url defined in ../routes.js
     const { authorSlug } = query
 
@@ -56,18 +47,15 @@ class NewsBody extends Component {
   render () {
     const {
       session,
-      url,
       authorSlug,
-      stories,
-      participate,
-      signIn
+      stories
     } = this.props
     const {
       playing,
       playerStory
     } = this.state
 
-    const isHome = (url.pathname === '/stories') && !authorSlug
+    const isHome = !authorSlug
     const isUsersPage = session && (authorSlug === session.slug)
     const noStories = stories && stories.length === 0
 
@@ -76,39 +64,30 @@ class NewsBody extends Component {
 
         {session && (isHome || isUsersPage) && (
           <div>
-            <button onClick={() => Router.pushRoute('/new-story')}>
+            <button onClick={() => Router.pushRoute('new-story')}>
               New Story
             </button>
-            <button onClick={() => Router.pushRoute('/edit-profile')}>
+            <button onClick={() => Router.pushRoute('edit-profile')}>
               Edit Profile
             </button>
           </div>
         )}
 
-        {/*
-          nasty hack to show participate and sign-in w/out stopping player
-          by just showing them all on the same page
-          when issue #88 gets addressed then we'll solve this elegantly
-          https://github.com/zeit/next.js/issues/88
-        */}
-
-        {participate ? <Participate /> : signIn ? <SignIn /> : (
-          <div>
-            {noStories && <p>No stories here...</p>}
-            {stories.map(story =>
-              <Story
-                key={`${story.authorId}_${story.createdAt}`}
-                story={story}
-                isUsersStory={session && session.id === story.authorId}
-                onPlayClick={this.onStoryPlayClick}
-              />
-            )}
-          </div>
-        )}
+        <div>
+          {noStories && <p>No stories here...</p>}
+          {stories.map(story => (
+            <Story
+              key={`${story.authorId}_${story.createdAt}`}
+              story={story}
+              isUsersStory={session && session.id === story.authorId}
+              onPlayClick={this.onStoryPlayClick}
+            />
+          ))}
+        </div>
 
         {Object.keys(playerStory).length > 0 && (
           <Player
-            url={playerStory.audio && playerStory.audio.publicUrl}
+            audioUrl={playerStory.audio && playerStory.audio.publicUrl}
             title={playerStory.title}
             playing={playing}
             setPlayState={this.setPlayState}

--- a/pages/stories.js
+++ b/pages/stories.js
@@ -4,15 +4,9 @@ import request from 'axios'
 import { Router } from '../routes'
 import Page from '../components/hoc/page'
 import Story from '../components/story'
-import Player from '../components/player'
 import config from '../config'
 
 class NewsBody extends Component {
-  state = {
-    playing: false,
-    playerStory: {}
-  }
-
   static async getInitialProps ({ query }) {
     // query.authorSlug comes from url defined in ../routes.js
     const { authorSlug } = query
@@ -32,28 +26,13 @@ class NewsBody extends Component {
     return { authorSlug, stories }
   }
 
-  onStoryPlayClick = story => this.setState({
-    playing: true,
-    playerStory: story
-  })
-
-  setPlayState = state => this.setState({ playing: state })
-  togglePlayPause = () => {
-    this.setState(prevState => ({
-      playing: !prevState.playing
-    }))
-  }
-
   render () {
     const {
       session,
       authorSlug,
-      stories
+      stories,
+      onStoryPlayClick
     } = this.props
-    const {
-      playing,
-      playerStory
-    } = this.state
 
     const isHome = !authorSlug
     const isUsersPage = session && (authorSlug === session.slug)
@@ -80,20 +59,10 @@ class NewsBody extends Component {
               key={`${story.authorId}_${story.createdAt}`}
               story={story}
               isUsersStory={session && session.id === story.authorId}
-              onPlayClick={this.onStoryPlayClick}
+              onPlayClick={onStoryPlayClick}
             />
           ))}
         </div>
-
-        {Object.keys(playerStory).length > 0 && (
-          <Player
-            audioUrl={playerStory.audio && playerStory.audio.publicUrl}
-            title={playerStory.title}
-            playing={playing}
-            setPlayState={this.setPlayState}
-            togglePlayPause={this.togglePlayPause}
-          />
-        )}
 
         <style jsx>{`
           button {

--- a/routes.js
+++ b/routes.js
@@ -19,21 +19,12 @@ const routes = module.exports = nextRoutes()
  * See https://github.com/fridays/next-routes
  */
 
-/*
- * i had to point participate and sign-in routes to stories.js to
- * keep the player playing through route transitions, at least on
- * the pages that a non-logged-in user has access to
- *
- * when issue #88 gets addressed then we'll solve this elegantly
- * https://github.com/zeit/next.js/issues/88
- */
-
 routes.add('stories', '/')
+routes.add('participate')
 routes.add('new-story')
 routes.add('edit-story', '/edit/:storySlug')
 routes.add('edit-profile')
-routes.add('participate', '/participate', 'stories')
-routes.add('sign-in', '/sign-in', 'stories')
+routes.add('sign-in', '/sign-in', 'auth/sign-in')
 routes.add('sign-out', '/sign-out', 'auth/sign-out')
 routes.add('confirm', '/registration/confirm', 'auth/confirm')
 routes.add('authorStories', '/:authorSlug', 'stories')

--- a/server.js
+++ b/server.js
@@ -9,10 +9,10 @@ const app = next({ dev })
 const handler = routes.getRequestHandler(app)
 
 app.prepare()
-.then(() => {
-  createServer(handler)
-  .listen(port, (err) => {
-    if (err) throw err
-    console.log(`> Ready on http://localhost:${port}`)
+  .then(() => {
+    createServer(handler)
+      .listen(port, (err) => {
+        if (err) throw err
+        console.log(`> Ready on http://localhost:${port}`)
+      })
   })
-})


### PR DESCRIPTION
Since next.js now allows a top level app component, we can get rid of our hack that kept the player playing through page transitions. 

This PR removes the references to `pages/sign-in.js` and `pages/participate.js` inside `pages/stories.js`, routes them normally, and moves the `Player` component to `pages/_app.js`.

Resolves #24 